### PR TITLE
Don't raise an exception when bin/sandi_meter is called without argument

### DIFF
--- a/bin/sandi_meter
+++ b/bin/sandi_meter
@@ -3,4 +3,4 @@
 require_relative '../lib/file_scanner'
 
 scanner = FileScanner.new(ARGV[1] == "--log")
-scanner.scan(ARGV[0])
+scanner.scan(ARGV[0] || '.')


### PR DESCRIPTION
Great fun lightning talk at Baruco. (Also, I find it amazing that you wrote that in such a short period of time).

Any yet…:

Without giving an existing path to the script it raised a Type Error (lib/file_scanner.rb:11:in `directory?': no implicit conversion of nil into String (TypeError)).
It now defaults to the current directory.

What do you think? I assume a more friendly message is also reasonable, along the lines of "sand_meter needs a file or directory name as an argument.
