### PR TITLE
Adding last line class with one-liner check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 pkg
 Gemfile.lock
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
   - jruby-19mode
   - jruby-20mode
   - jruby-head
+before_install:
+  - gem install bundler -v 1.13.1
 script:
   - bundle exec rake debug
 

--- a/lib/sandi_meter/analyzer.rb
+++ b/lib/sandi_meter/analyzer.rb
@@ -5,11 +5,12 @@ require_relative 'method_arguments_counter'
 require_relative 'sandi_meter/class'
 require_relative 'sandi_meter/method_call'
 require_relative 'sandi_meter/method'
+require_relative 'last_line'
 
 module SandiMeter
   class Analyzer
     attr_accessor :parent_token, :private_or_protected
-    attr_reader :classes, :methods, :method_calls
+    attr_reader :classes, :methods, :method_calls, :file_lines
 
     def initialize
       @classes = []
@@ -80,13 +81,8 @@ module SandiMeter
       }
     end
 
-    def find_last_line(line, token = 'class')
-      token_indentation = @file_lines[line - 1].index(token)
-      # TODO
-      # add check for trailing spaces
-      last_line = @file_lines[line..-1].index { |l| l =~ %r(\A\s{#{token_indentation}}end\s*\z) }
-
-      last_line ? last_line + line + 1 : nil
+    def find_last_line(start_line_number, token = 'class')
+      SandiMeter::LastLine.find(start_line_number, token, file_lines)
     end
 
     def scan_class_sexp(element, current_namespace = '')

--- a/lib/sandi_meter/last_line.rb
+++ b/lib/sandi_meter/last_line.rb
@@ -1,0 +1,67 @@
+# Namespace for all SandiMeter modules classes
+module SandiMeter
+  # Class to calculate last line of given object definition (class, module, method, etc)
+  # @author Paul Pettengill (github: prpetten)
+  class LastLine
+    class << self
+      # Finds last line given starting line number, token, and file_lines
+      # @note If last line is same as first line, it returns nil
+      # @note If last line can not be determined, it returns nil
+      # @param start_line_number [Numeric] Starting line number for (class, module, method, etc)
+      # @param token [String] start of object definition (eg 'class', 'module', 'def', ect)
+      # @param file_lines [Array<String>] each line of file in an array
+      # @return [Numeric] Line number for last line of object definition (class, module, method, etc)
+      def find(start_line_number, token, file_lines)
+        @start_line_number = start_line_number
+        @token = token
+        @file_lines = file_lines
+        determine_last_line
+      end
+
+      private
+
+      attr_reader :start_line_number, :token, :file_lines
+
+      def determine_last_line
+        return nil if one_liner?
+        end_line_index = end_line_at_indent
+        return nil if end_line_index.nil?
+        last_line_number(end_line_index)
+      end
+
+      # @note Since end_line_at_index is the index of ending line offset from start line,
+      #   the following must be done to derive the actual last_line_number
+      #   1 must be added to account for array index starting at zero
+      #   starting_line_number must be added to account for initial offset in remaining lines
+      def last_line_number(end_line_index)
+        start_line_number + end_line_index + 1
+      end
+
+      def token_indentation
+        first_line.index(token)
+      end
+
+      def one_liner?
+        %r(\A\s*#{token}.+end\s*\z) === first_line
+      end
+
+      def first_line
+        file_lines[start_line_number - 1]
+      end
+
+      def end_line_at_indent
+        remaining_lines.index do |line|
+          line =~ end_at_indent_regex
+        end
+      end
+
+      def remaining_lines
+        file_lines[start_line_number..-1]
+      end
+
+      def end_at_indent_regex
+        %r(\A\s{#{token_indentation}}end\s*\z)
+      end
+    end
+  end
+end

--- a/sandi_meter.gemspec
+++ b/sandi_meter.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 2.13"
 
   spec.add_runtime_dependency "mixlib-cli"
-  spec.add_runtime_dependency "json"
+  spec.add_runtime_dependency "json", "~> 1.8.3"
   spec.add_runtime_dependency "launchy"
 end

--- a/spec/analyzer_spec.rb
+++ b/spec/analyzer_spec.rb
@@ -359,7 +359,7 @@ describe SandiMeter::Analyzer do
     end
   end
 
-  describe 'analazing complex methods' do
+  describe 'analyzing complex methods' do
     let(:test_class) { test_file_path(14) }
     let(:methods) { analyzer.methods["TestClass"] }
 
@@ -398,6 +398,26 @@ describe SandiMeter::Analyzer do
         number_of_arguments: 0,
         path: test_file_path(14)
       )
+    end
+  end
+
+  describe 'analyzing 1 line methods' do
+    let(:test_class) { test_file_path(16) }
+    let(:methods) { analyzer.methods['TestClass'] }
+
+    before do
+      analyzer.analyze(test_class)
+    end
+
+    it 'sets last_line to nil' do
+      method = analyzer.methods['TestClass'].find { |method| method.name == 'method1' }
+
+      expect(method).to have_attributes(
+                          first_line: 2,
+                          last_line: nil,
+                          number_of_arguments: 0,
+                          path: test_file_path(16)
+                        )
     end
   end
 end

--- a/spec/last_line_spec.rb
+++ b/spec/last_line_spec.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+require_relative '../lib/sandi_meter/last_line'
+
+describe SandiMeter::LastLine do
+  describe '.find' do
+    shared_examples_for 'finding last line number' do
+      let(:file_lines) { ["#{token} A; end",
+                          "#{token} B",
+                          '  if test_true?',
+                          '    puts "Hi Mom"',
+                          '  end',
+                          'end',
+                          "#{token} C",
+                          '  unless test_false?',
+                          '    puts "Hey Dad"',
+                          '  end',
+                          '  end'] }
+      context 'when one liner' do
+
+        let(:start_line) { 1 }
+        it 'returns nil' do
+          expect(described_class.find(start_line, token, file_lines)).to be_nil
+        end
+      end
+
+      context 'when multiline' do
+        context 'when end found with same indentation' do
+          let(:start_line) { 2 }
+          it 'returns line number of last line' do
+            expect(described_class.find(start_line, token, file_lines)).to eq(6)
+          end
+        end
+
+        context 'when no end found with same indentation' do
+          let(:start_line) { 7 }
+          it 'returns nil' do
+            expect(described_class.find(start_line, token, file_lines)).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'when class token' do
+      let(:token) { 'class' }
+      it_should_behave_like 'finding last line number'
+    end
+
+    context 'when module token' do
+      let(:token) { 'module' }
+      it_should_behave_like 'finding last line number'
+    end
+
+    context 'when def token (method)' do
+      let(:token) { 'def' }
+      it_should_behave_like 'finding last line number'
+    end
+  end
+end

--- a/spec/test_classes/16.rb
+++ b/spec/test_classes/16.rb
@@ -1,0 +1,12 @@
+class TestClass
+  def method1; end
+
+  def method2; end
+
+  def method3; end
+
+  def method4; end
+
+  def method2
+  end
+end


### PR DESCRIPTION
This commit fixes #66 
- Wrote failing test under `describe 'analyzing 1 line methods' do ...` block
- Fixed one line method definition counts, by fixing the underlying issue in the `SandiMeter::Analyzer#last_line` method.
- Refactored internals of `SandiMeter::Analyzer#last_line` into its own class with corresponding specs and documentation.
- Added attr_reader for `file_lines` instance variable
- Added `.idea/` to `.gitignore` for Rubymine usage during development
- Added 2.2, 2.3, and `gem install bundler -v 1.13.1` to `.travis.yml` for completeness and to fix issue with TravisCI and jruby-head not having bundler installed
- Added minor version dependency to `json` gem at `~> 1.8.3` as `2.0.0` and higher require ruby to be at 2.0 or higher, which was causing build at 1.9.3 to fail.
