### PR TITLE
Create config file with correct values

### DIFF
--- a/lib/sandi_meter/cli.rb
+++ b/lib/sandi_meter/cli.rb
@@ -97,7 +97,7 @@ module SandiMeter
           FileUtils.mkdir_p(cli.config[:output_path]) unless Dir.exists?(cli.config[:output_path])
 
           create_config_file(cli.config[:output_path], '.sandi_meter', %w(db vendor).join("\n"))
-          create_config_file(cli.config[:output_path], 'config.yml', YAML.dump({ thresholds: [90, 90, 90, 90] }))
+          create_config_file(cli.config[:output_path], 'config.yml', YAML.dump({ thresholds: cli.config[:rule_thresholds] }))
         end
 
         if cli.config[:version]


### PR DESCRIPTION
(fixes #69)

If both graph and thresholds are set, the incorrect value for thresholds are stored in the config file.  This will store the correct values.

Is there a reason why this file is being auto created only when the --graph option is passed in?